### PR TITLE
Some UI improvements

### DIFF
--- a/imports/ui/admin/system.jsx
+++ b/imports/ui/admin/system.jsx
@@ -276,7 +276,6 @@ class System extends Component {
                             value={this.state.sapporo.title}
                             onChange={this.updateSapporo.bind(this, 'title')}
                         />
-                        <br />
                         <TextField
                             type="text"
                             fullWidth
@@ -285,7 +284,6 @@ class System extends Component {
                             value={this.state.sapporo.appTitle}
                             onChange={this.updateSapporo.bind(this, 'appTitle')}
                         />
-                        <br />
                         <TextField
                             type="text"
                             fullWidth
@@ -294,7 +292,6 @@ class System extends Component {
                             value={this.state.sapporo.surveyURL}
                             onChange={this.updateSapporo.bind(this, 'surveyURL')}
                         />
-                        <br />
                         <TextField
                             type="number"
                             min="0"

--- a/imports/ui/problemEditor.jsx
+++ b/imports/ui/problemEditor.jsx
@@ -88,9 +88,18 @@ class ProblemEditor extends Component {
     }
     renderLangOptions () {
         if (!this.props._docker) return;
-        return this.props._docker.map((lang, key) => (
-            <MenuItem key={key} value={lang.title} primaryText={lang.title}></MenuItem>
-        ));
+        return this.props._docker
+            .sort((a, b) => {
+                a = String(a.title), b = String(b.title);
+                return a > b ? 1 : (a < b ? -1 : 0);
+            })
+            .map((lang, key) => (
+                <MenuItem
+                    key={key}
+                    value={String(lang.title)}
+                    primaryText={String(lang.title)}
+                />
+            ));
     }
     updateTheme(event, index, value) {
         this.setState({


### PR DESCRIPTION
- On the **Problem Editor** screen, the language options are displayed in an ascending order alphabetically, no matter in what order they were created by the admin.
- Remove hard line-breaks between fields on **System Settings** --> to keep the "flex".