### PR TITLE
Improve problem editor display

### DIFF
--- a/client/css/main.scss
+++ b/client/css/main.scss
@@ -18,10 +18,36 @@ html {
     text-overflow: ellipsis;
 }
 
+dl.in-out-examples dt {
+    font-size: .75rem;
+    margin: 2em 0 0;
+    line-height: 1.375em;
+    color: rgba(0,0,0,.5);
+}
+dl.in-out-examples dd {
+    margin: 0;
+    padding: 0;
+}
+dl.in-out-examples dd pre {
+    margin: 0;
+}
+
+pre.code-entry,
 .code-entry textarea {
-    font-family: "Roboto Mono", Consolas, Monaco, monospace !important;
-    font-size: .875em !important;
-    line-height: 1.71428571429 !important;
-    padding: 0 6px !important;
     background-color: #eceff1 !important;
+}
+.code-entry textarea {
+    padding: 0 .4286em !important;
+}
+pre.code-entry {
+    padding: .5em;
+    overflow: auto;
+}
+.code-entry code,
+.code-entry samp,
+.code-entry textarea {
+    font-family: Monaco, Menlo, "Ubuntu Mono", "Roboto Mono", Consolas,
+        source-code-pro, monospace !important;
+    font-size: .875em !important;
+    line-height: 1.7143 !important;
 }

--- a/imports/ui/problemEditor.jsx
+++ b/imports/ui/problemEditor.jsx
@@ -348,16 +348,20 @@ class ProblemEditor extends Component {
                         style={{
                             display: 'inline-block',
                             width: '100%',
-                            padding: '10px 0'
+                            padding: '10px 0 0 0'
                         }}
                     >
                         <Paper
-                            style={{width: '49.5%', float: 'left'}}
+                            style={{
+                                float: 'left',
+                                width: '49.5%',
+                                maxHeight: 'calc(100vh - 94px)',
+                                overflow: 'auto'
+                            }}
                             zDepth={1}
                         >
                             <div style={textDiv}>
                                 <SelectField
-                                    //value={this.state.languageOverride}
                                     value={langIso}
                                     onChange={this.updateDisplayLang.bind(this)}
                                     floatingLabelText="Display Language"
@@ -372,14 +376,6 @@ class ProblemEditor extends Component {
                                     display: 'flex'
                                 }
                             }>
-                                {/* <TextField
-                                    floatingLabelText="Title"
-                                    type="text"
-                                    underlineShow={false}
-                                    style={{width: '70%', marginRight: '1em'}}
-                                    inputStyle={{fontSize: '1.375em', fontWeight: 'bold'}}
-                                    value={this.props.data.title[langIso]}
-                                /> */}
                                 <div
                                     style={{
                                         width: 'calc(100% - 3.27272727273em)',
@@ -408,16 +404,6 @@ class ProblemEditor extends Component {
                                 />
                             </div>
                             <div style={textDiv}>
-                                {/* <TextField
-                                    floatingLabelText="Description"
-                                    type="text"
-                                    underlineShow={false}
-                                    style={{width: '100%'}}
-                                    multiLine={true}
-                                    rows={2}
-                                    rowsMax={10}
-                                    value={this.props.data.description[langIso]}
-                                /> */}
                                 <div
                                     style={{
                                         whiteSpace: 'pre-wrap',
@@ -429,46 +415,40 @@ class ProblemEditor extends Component {
                                 </div>
                             </div>
                             <div style={textDiv}>
-                                <TextField
-                                    floatingLabelText="Input Example"
-                                    floatingLabelFixed={true}
-                                    type="text"
-                                    multiLine={true}
-                                    rows={1}
-                                    rowsMax={10}
-                                    underlineShow={false}
-                                    className="code-entry"
-                                    style={{width: '100%'}}
-                                    value={
-                                        this.props.data.exampleInput[langIso] ?
-                                            this
-                                            .props
-                                            .data
-                                            .exampleInput[langIso]
-                                            : ''
-                                    }
-                                />
-                            </div>
-                            <div style={textDiv}>
-                                <TextField
-                                    floatingLabelText="Output Example"
-                                    floatingLabelFixed={true}
-                                    type="text"
-                                    multiLine={true}
-                                    rows={1}
-                                    rowsMax={10}
-                                    underlineShow={false}
-                                    className="code-entry"
-                                    style={{width:'100%'}}
-                                    value={
-                                        this.props.data.exampleOutput[langIso] ?
-                                            this
-                                            .props
-                                            .data
-                                            .exampleOutput[langIso]
-                                            : ''
-                                    }
-                                />
+                                <dl className="in-out-examples">
+                                    <dt>Input Example</dt>
+                                    <dd>
+                                        <pre className="code-entry">
+                                            <code>{
+                                                this
+                                                .props
+                                                .data
+                                                .exampleInput[langIso] ?
+                                                    this
+                                                    .props
+                                                    .data
+                                                    .exampleInput[langIso]
+                                                    : ''
+                                            }</code>
+                                        </pre>
+                                    </dd>
+                                    <dt>Output Example</dt>
+                                    <dd>
+                                        <pre className="code-entry">
+                                            <samp>{
+                                                this
+                                                .props
+                                                .data
+                                                .exampleOutput[langIso] ?
+                                                    this
+                                                    .props
+                                                    .data
+                                                    .exampleOutput[langIso]
+                                                    : ''
+                                            }</samp>
+                                        </pre>
+                                    </dd>
+                                </dl>
                             </div>
                             {
                                 (this.props.data.images.length > 0) ?
@@ -546,7 +526,7 @@ class ProblemEditor extends Component {
                                         width='100%'
                                         name="UNIQUE_ID_OF_DIV"
                                         editorProps={editorOption}
-                                        height="75vh"
+                                        height="calc(100vh - 166px)"
                                     /> :
                                     <span>
                                         Choose a programming language to start


### PR DESCRIPTION
- Abandoned use of textarea element to hold input/output examples to
  avoid extra scrolling in boxes of limited rows. Semantic markups were
  used instead.
- Made "problem display" area on the left size to be no taller than the
  height of the viewport, and scrollable for overflowed content.
- Made the code editor occupy the rest of the viewport vertically.
- Also improved the layout of input/output examples, with a sane list of
  chosen font-faces cross different systems, proper text line-height &
  margins, etc.